### PR TITLE
Catch ClassCastException when disabling Xposed

### DIFF
--- a/brevent/src/main/java/me/piebridge/brevent/ui/BreventActivity.java
+++ b/brevent/src/main/java/me/piebridge/brevent/ui/BreventActivity.java
@@ -192,7 +192,7 @@ public class BreventActivity extends Activity
             disabledXposed = true;
         } catch (ClassNotFoundException | PackageManager.NameNotFoundException e) {
             // do nothing
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             UILog.d("Can't disable Xposed", e);
         }
         if (BuildConfig.RELEASE) {


### PR DESCRIPTION
Hook getDeclaredField() and set result to new Object() makes it happen.